### PR TITLE
getColumnIndex requires a String for a column name

### DIFF
--- a/src/main/scala/org/kududb/spark/DefaultSource.scala
+++ b/src/main/scala/org/kududb/spark/DefaultSource.scala
@@ -172,7 +172,7 @@ class KuduRelation (val tableName:String,
 
 
     val columnSchema = getKuduSchemaColumnMap.getOrElse(columnName, null)
-    val columnIndex = row.getColumnProjection.getColumnIndex(columnSchema)
+    val columnIndex = row.getColumnProjection.getColumnIndex(columnName)
     val columnType = columnSchema.getType
 
     if (columnType == Type.BINARY) row.getBinary(columnIndex)


### PR DESCRIPTION
Fixing a compile error by passing in a String column name: http://getkudu.io/apidocs/org/kududb/Schema.html#getColumnIndex-java.lang.String-
